### PR TITLE
Fix - allow both Base64 encoded and non-Base64 Client Secret

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-functions-auth0",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Authenticate your Azure Functions with Auth0",
   "main": "lib/index.js",
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,8 @@ module.exports = (options) => {
   }
 
   const middleware = jwt({
-    secret: new Buffer(options.clientSecret, 'base64'),
+    //Auth0 stops generating Base64 Client Secret after 6th Dec, so this has to allow both
+    secret: options.isSecretBase64 ? new Buffer(options.clientSecret, 'base64') : options.clientSecret,
     audience: options.clientId,
     issuer: 'https://' + options.domain + '/'
   });


### PR DESCRIPTION
Auth0 stops generating Base64 Client Secret from 6th Dec, so this is to allow for both kind of secrets