### PR TITLE
Fix error return to Azure Functions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,14 +28,14 @@ module.exports = (options) => {
     return (context, req) => {
       middleware(req, null, (err) => {
         if (err) {
-          context.res = {
+          var res = {
             status: err.status || 500,
             body: {
               message: err.message
             }
           };
 
-          return context.done();
+          return context.done(null, res);
         }
 
         return next(context, req);


### PR DESCRIPTION
The way that res was being returned was getting lost for me when testing from the functions console. Perhaps it no longer works that way?